### PR TITLE
Raise an error if encode-base64 input is not a string

### DIFF
--- a/templates/utilities/encode-base64/run.js
+++ b/templates/utilities/encode-base64/run.js
@@ -20,10 +20,10 @@
   const { plainText } = input;
 
   try {
-    if (plainText === "") {
+    if (typeof plainText !== "string") {
+      throw new Error("The input provided is not a string");
+    } else if (plainText === "") {
       throw new Error("Plain text cannot be empty")
-    } else if (typeof plainText !== "string") {
-      throw new Error("The input provided is not a string!");
     }
     const encoded = Buffer.from(plainText).toString('base64');
     return encoded;

--- a/templates/utilities/encode-base64/run.js
+++ b/templates/utilities/encode-base64/run.js
@@ -22,6 +22,8 @@
   try {
     if (plainText === "") {
       throw new Error("Plain text cannot be empty")
+    } else if (typeof plainText !== "string") {
+      throw new Error("The input provided is not a string!");
     }
     const encoded = Buffer.from(plainText).toString('base64');
     return encoded;


### PR DESCRIPTION
Check if the input is a string, if not it will raise an error.